### PR TITLE
Prevent cancelled builds from showing as errors.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,3 +44,9 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+      - name: Ensure canceled builds output as warnings not errors
+        if: ${{ cancelled() }}
+        run: |
+          printenv
+          echo "::notice::Deployment was cancelled, likely because there were multiple edits to a page."
+          exit 0


### PR DESCRIPTION
We dont want scary emails being sent to contributors.